### PR TITLE
Query command migrations

### DIFF
--- a/src/commands/query/gameDeal.js
+++ b/src/commands/query/gameDeal.js
@@ -75,21 +75,6 @@ module.exports = {
           })
           return
         }
-        // =========================
-        // Helpers
-        // =========================
-
-        /**
-         * Convert number to currency format
-         * @param {number} num
-         * @returns {string}
-         */
-        function toCurrency(num) {
-          const price = Number.parseFloat(num).toFixed(2)
-
-          return price > 0 ? `$${price}` : 'FREE'
-        }
-        return
       }
 
       // Can't rely on user input for the formal game name.

--- a/src/commands/query/gameDeal.js
+++ b/src/commands/query/gameDeal.js
@@ -1,0 +1,153 @@
+const { CommandType } = require('wokcommands')
+const { EmbedBuilder } = require('discord.js')
+
+const itadAPI = require('../../util/itadAPI')
+
+module.exports = {
+  type: CommandType.SLASH,
+  description: 'Lookup if there is a deal for a game.',
+  guildOnly: true,
+  minArgs: 1,
+  expectedArgs: 'The game being searched for.',
+  testOnly: false,
+  options: [
+    {
+      name: 'game',
+      description: 'What game are you searching for a deal on?',
+      type: 3,
+      required: true,
+    },
+  ],
+
+  callback: async ({ interaction }) => {
+    //Setup variables
+    const gameName = await interaction.options.getString('game').toLowerCase()
+
+    const ignoredSellers = [
+      '2game',
+      'allyouplay',
+      'bistore',
+      'dlgamer',
+      'direct2drive',
+      'dreamgame',
+      'fireflower',
+      'impuse',
+      'gamesplanet',
+      'gamesplanetfr',
+      'gamesplanetus',
+      'gamesrepublic',
+      'gemly',
+      'lbostore',
+      'nuuvem',
+      'playism',
+      'silagames',
+      'voidu',
+      'wingamestore',
+      'gamesplanetde',
+      'gamesload',
+      'gamersgate',
+    ]
+
+    let author = await interaction.guild.members.fetch(interaction.user.id)
+
+    try {
+      const gameId = await itadAPI.getGameId(gameName)
+
+      if (!gameId) {
+        const gameList = await itadAPI.search(gameName)
+
+        if (gameList.length > 0) {
+          // Map titles, remove duplicates, sort alphabetically
+          const titles = gameList
+            .map((x) => x.title)
+            .filter((v, i, a) => a.indexOf(v) === i)
+            .sort()
+
+          interaction.reply({
+            content: `Could not lookup ${gameName} \n\n Here are some suggestions: \n ${titles.join(
+              '\n'
+            )}`,
+          })
+        } else {
+          interaction.reply({
+            content: `Could not look up ${gameName}. Did you spell it correctly?`,
+            ephemeral: true,
+          })
+          return
+        }
+        // =========================
+        // Helpers
+        // =========================
+
+        /**
+         * Convert number to currency format
+         * @param {number} num
+         * @returns {string}
+         */
+        function toCurrency(num) {
+          const price = Number.parseFloat(num).toFixed(2)
+
+          return price > 0 ? `$${price}` : 'FREE'
+        }
+        return
+      }
+
+      // Can't rely on user input for the formal game name.
+      // Formal name also isn't returned with game data in the next step.
+      const gameInfo = await itadAPI.getGameInfo(gameId)
+      const gameData = await itadAPI.getGameData(gameId, ignoredSellers)
+      const list = gameData.list.filter((x) => x.price_new < x.price_old)
+
+      if (!gameData || list.length === 0) {
+        interaction.reply({
+          content: `Currently unable to find deal for ${gameName}`,
+        })
+        return
+      }
+
+      const sellers = list.map((x) => `[${x.shop.name}](${x.url})`)
+      const newPrices = list.map(
+        (x) => `${toCurrency(x.price_new)} (-${x.price_cut}%)`
+      )
+      const oldPrices = list.map((x) => toCurrency(x.price_old))
+      const histLowData = await itadAPI.getHistoricalLow(gameId)
+
+      const dealEmbed = new EmbedBuilder()
+        .setTitle(gameInfo.title || gameId)
+        .setURL(gameData.urls.game)
+        .setColor(process.env.EMBED)
+        .setImage(gameInfo.image)
+        .setFooter({ text: `Requested by ${author.user.username} | ITAD API` })
+        .addFields(
+          { name: 'Seller', value: sellers.join('\n'), inline: true },
+          { name: 'New Price', value: newPrices.join('\n'), inline: true },
+          { name: 'Old Price', value: oldPrices.join('\n'), inline: true }
+        )
+
+      interaction.reply({
+        content: '',
+        embeds: [dealEmbed],
+      })
+    } catch (err) {
+      interaction.reply({
+        content: 'Something went wrong!',
+        ephemeral: true,
+      })
+      return console.log(err)
+    }
+    // =========================
+    // Helpers
+    // =========================
+
+    /**
+     * Convert number to currency format
+     * @param {number} num
+     * @returns {string}
+     */
+    function toCurrency(num) {
+      const price = Number.parseFloat(num).toFixed(2)
+
+      return price > 0 ? `$${price}` : 'FREE'
+    }
+  },
+}

--- a/src/commands/query/imdb.js
+++ b/src/commands/query/imdb.js
@@ -1,0 +1,149 @@
+const { CommandType } = require('wokcommands')
+const { EmbedBuilder } = require('discord.js')
+
+const funHelper = require('../../util/funHelper')
+
+module.exports = {
+  type: CommandType.SLASH,
+  description:
+    'Search The Movie Database for info on movies, series, or actors.',
+  guildOnly: true,
+  minArgs: 2,
+  expectedArgs: 'Search type and name',
+  testOnly: false,
+  options: [
+    {
+      name: 'type',
+      description: 'Movie, Series, or Actor?',
+      type: 3,
+      required: true,
+    },
+    {
+      name: 'name',
+      description: 'Name to search for?',
+      type: 3,
+      required: true,
+    },
+  ],
+
+  callback: async ({ interaction }) => {
+    // Setup variables
+    const searchType = await interaction.options.getString('type').toLowerCase()
+    var searchName = await interaction.options.getString('name').toLowerCase()
+    var searchName = searchName.substring().split(' ')
+    var searchName = searchName.join('%20')
+
+    const author = await interaction.guild.members.fetch(interaction.user.id)
+
+    try {
+      if (searchType === 'movie') {
+        const movieData = await funHelper.tmdb(searchType, searchName)
+
+        const movieEmbed = new EmbedBuilder()
+          .setTitle(movieData.title)
+          .setColor(process.env.EMBED)
+          .setFooter({
+            text: `Requested by ${author.user.username} | TMDB API`,
+          })
+          .setDescription(movieData.overview)
+          .setThumbnail(
+            'https://image.tmdb.org/t/p/w500' + movieData.poster_path
+          )
+          .addFields(
+            {
+              name: 'User Rating',
+              value: movieData.vote_average.toFixed(1) + '/10',
+              inline: true,
+            },
+            {
+              name: 'Release Date',
+              value: movieData.release_date,
+              inline: true,
+            },
+            {
+              name: 'More Infor',
+              value: `[TMDB](https://www.themoviedb.org/movie/${movieData.id})`,
+            }
+          )
+
+        return interaction.reply({
+          content: '',
+          embeds: [movieEmbed],
+        })
+      } else if (searchType === 'series') {
+        const seriesData = await funHelper.tmdb(searchType, searchName)
+
+        const seriesEmbed = new EmbedBuilder()
+          .setTitle(seriesData.name)
+          .setColor(process.env.EMBED)
+          .setFooter({
+            text: `Requested by ${author.user.username} | TMDB API`,
+          })
+          .setDescription(seriesData.overview)
+          .setThumbnail(
+            'https://image.tmdb.org/t/p/w500' + seriesData.poster_path
+          )
+          .addFields(
+            {
+              name: 'User Rating',
+              value: seriesData.vote_average.toFixed(1) + '/10',
+              inline: true,
+            },
+            {
+              name: 'Air Date',
+              value: seriesData.first_air_date,
+              inline: true,
+            },
+            {
+              name: 'More Info',
+              value: `[TMDB](https://www.themoviedb.org/tv/${seriesData.id})`,
+            }
+          )
+
+        return interaction.reply({
+          content: '',
+          embeds: [seriesEmbed],
+        })
+      } else if (searchType === 'actor') {
+        const actorData = await funHelper.tmdb(searchType, searchName)
+
+        const actorEmbed = new EmbedBuilder()
+          .setTitle(actorData.name)
+          .setColor(process.env.EMBED)
+          .setFooter({
+            text: `Requested by ${author.user.username} | TMDB API`,
+          })
+          .setThumbnail(
+            'https://image.tmdb.org/t/p/w500' + actorData.profile_path
+          )
+          .addFields(
+            {
+              name: 'Known For',
+              value: `${actorData.known_for[0].title}, ${actorData.known_for[1].title}, ${actorData.known_for[2].title}`,
+            },
+            {
+              name: 'More Info',
+              value: `[TMDB](https://www.themoviedb.org/person/${actorData.id})`,
+            }
+          )
+
+        return interaction.reply({
+          content: '',
+          embeds: [actorEmbed],
+        })
+      } else {
+        interaction.reply({
+          content: 'Please enter Movie, Series, or Actor for type.',
+          ephemeral: true,
+        })
+        return
+      }
+    } catch (err) {
+      interaction.reply({
+        content: 'Something went wrong!',
+        ephemeral: true,
+      })
+      return console.log(err)
+    }
+  },
+}

--- a/src/util/funHelper.js
+++ b/src/util/funHelper.js
@@ -98,9 +98,49 @@ const kitsu = async (type, name) => {
   }
 }
 
+const tmdb = async (type, name) => {
+  if (type === 'movie') {
+    const movieSearch = await axios.get(
+      'https://api.themoviedb.org/3/search/movie?api_key=' +
+        process.env.TMDB +
+        '&query=' +
+        name +
+        '&page=1&include_adult=false'
+    )
+
+    const movieData = movieSearch.data.results[0]
+    return movieData
+  } else if (type === 'series') {
+    const seriesSearch = await axios.get(
+      'https://api.themoviedb.org/3/search/tv?api_key=' +
+        process.env.TMDB +
+        '&query=' +
+        name +
+        '&page=1'
+    )
+
+    const seriesData = seriesSearch.data.results[0]
+    return seriesData
+  } else if (type === 'actor') {
+    const actorSearch = await axios.get(
+      'https://api.themoviedb.org/3/search/person?api_key=' +
+        process.env.TMDB +
+        '&query=' +
+        name +
+        '&page=1&include_adult=false'
+    )
+
+    const actorData = actorSearch.data.results[0]
+    return actorData
+  } else {
+    return
+  }
+}
+
 module.exports = {
   eightBall,
   insult,
   cute,
   kitsu,
+  tmdb,
 }

--- a/src/util/itadAPI.js
+++ b/src/util/itadAPI.js
@@ -1,0 +1,139 @@
+/**
+ * * Credit to adamdavies001
+ * * git: https://github.com/adamdavies001/isthereanydeal-lookup
+ */
+const axios = require('axios')
+
+const ITAD_KEY = process.env.ITAD
+const BASE_URL = 'https://api.isthereanydeal.com'
+
+/**
+ * Search for game by name
+ * @param {string} game
+ * @returns {Array}
+ */
+const search = async (game) => {
+  const res = await axios.get(`${BASE_URL}/v01/search/search/`, {
+    params: {
+      key: ITAD_KEY,
+      q: game,
+      region: 'us',
+      country: 'US',
+    },
+  })
+
+  const searchData = res.data.data
+  const list =
+    searchData &&
+    searchData.list.sort((a, b) => a.title.length - b.title.length)
+
+  return list
+}
+
+/**
+ * Get ITAD game ID
+ * @param {string} game
+ * @returns {string}
+ */
+const getGameId = async (game) => {
+  const res = await axios.get(`${BASE_URL}/v02/game/plain/`, {
+    params: {
+      key: ITAD_KEY,
+      title: game,
+    },
+  })
+
+  const plainData = res.data.data
+  const gameId = plainData && plainData.plain
+
+  return gameId
+}
+
+/**
+ * Get game info from ID
+ * @param {string} gameId ITAD internal game ID
+ * @returns {Object}
+ */
+const getGameInfo = async (gameId) => {
+  const res = await axios.get(`${BASE_URL}/v01/game/info/`, {
+    params: {
+      key: ITAD_KEY,
+      plains: gameId,
+      optional: 'metacritic',
+    },
+  })
+
+  const infoData = res.data.data && res.data.data[gameId]
+
+  return infoData
+}
+
+/**
+ * Get game prices and links
+ * @param {string} gameId ITAD internal game ID
+ * @returns {Object}
+ */
+const getGameData = async (gameId, ignoredSellers) => {
+  const res = await axios.get(`${BASE_URL}/v01/game/prices/`, {
+    params: {
+      key: ITAD_KEY,
+      plains: gameId,
+      region: 'us',
+      country: 'US',
+      exclude: ignoredSellers.join(','),
+    },
+  })
+
+  const gameData = res.data.data && res.data.data[gameId]
+
+  return gameData
+}
+
+/**
+ * Get historical low for game
+ * @param {string} gameId ITAD internal game ID
+ * @returns {Object}
+ */
+const getHistoricalLow = async (gameId) => {
+  const res = await axios.get(`${BASE_URL}/v01/game/lowest/`, {
+    params: {
+      key: ITAD_KEY,
+      plains: gameId,
+      region: 'us',
+      country: 'US',
+    },
+  })
+
+  const gameData = res.data.data && res.data.data[gameId]
+
+  return gameData
+}
+
+/**
+ * Get Metacritic game summary and reviews
+ * @param {string} seller Full seller name
+ * @returns {string}
+ */
+const getSellerId = async (seller) => {
+  const res = await axios.get(`${BASE_URL}/v02/web/stores/`, {
+    params: {
+      region: 'us',
+      country: 'US',
+    },
+  })
+
+  const sellers = res.data && res.data.data
+  const filteredSellers = sellers.filter((x) => x.title === seller)
+  const sellerId = filteredSellers.length > 0 && filteredSellers[0].id
+
+  return sellerId
+}
+
+module.exports = {
+  search,
+  getGameId,
+  getGameInfo,
+  getGameData,
+  getHistoricalLow,
+  getSellerId,
+}


### PR DESCRIPTION
Migrated the following commands:

* gamedeal (previously *deal*), migrated itadAPI helper file as well for functionality.
* kitsu (merged *anime* and *manga* commands). Included kitsu helper code into funHelper file.
* imdb (no changes to made to name or function). Included tmdb helper code into funHelper file.

Require:

With these additions .env variables must include both ITAD and TMDB API keys to function or will result in a failure/crash.