### PR TITLE
Dockerfile Update [fix]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@ npm-debug.log
 yarn-error.log
 yarn.lock
 .github
-.circleci
+.package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.env
+/docker/.env
 /node_modules
 /yarn-error.log
 /docker/docker-compose.yml
 /prod.env
-/yarn.lock
-/package.lock
+/package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "conventionalCommits.scopes": [
+    "docker"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM node:latest
+FROM node:lts-bookworm
 
-RUN mkdir -p /usr/src/bot
-WORKDIR /usr/src/bot
-
-COPY . /usr/src/bot
+RUN mkdir /bot
+WORKDIR /bot
+COPY . /bot
 
 RUN npm install
-
-COPY . /usr/src/bot
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Updated Dockerfile from node:latest to node:lts-bookworm. Alpine and lts-bookworm-slim continue to give errors on build at the following step:

```
RUN npm install
```

Will continue to investigate.